### PR TITLE
Heatmap appearance change

### DIFF
--- a/app/src/main/java/com/wifiheatmap/wifiheatmap/MapsFragment.kt
+++ b/app/src/main/java/com/wifiheatmap/wifiheatmap/MapsFragment.kt
@@ -386,6 +386,7 @@ class MapsFragment : Fragment(), OnMapReadyCallback, Observer<List<Data>> {
             Timber.d("Radius of each point: %s", zoomLevel)
         }
         heatmapTileProvider?.setRadius(zoomLevel ?: 10)
+        heatmapTileProvider?.setMaxIntensity(50.0) // based off of analysis of data as we put it in the database.
         heatmapTileProvider?.setWeightedData(heatmapData)
         tileOverlay?.clearTileCache()
     }

--- a/app/src/main/java/com/wifiheatmap/wifiheatmap/MapsFragment.kt
+++ b/app/src/main/java/com/wifiheatmap/wifiheatmap/MapsFragment.kt
@@ -44,7 +44,7 @@ class MapsFragment : Fragment(), OnMapReadyCallback, Observer<List<Data>> {
 
     private var viewNetwork: String = ""
 
-    private val MAX_INTENSITY = 10;
+    private val MAX_INTENSITY = 10
 
     private lateinit var mapsViewModel: MapsViewModel
     private lateinit var viewModel: ViewModel

--- a/app/src/main/java/com/wifiheatmap/wifiheatmap/MapsFragment.kt
+++ b/app/src/main/java/com/wifiheatmap/wifiheatmap/MapsFragment.kt
@@ -4,6 +4,7 @@ import android.content.pm.PackageManager
 import android.graphics.Color
 import android.location.Location
 import android.net.wifi.ScanResult
+import android.net.wifi.WifiManager
 import android.os.Bundle
 import android.view.*
 import android.widget.Toast
@@ -42,6 +43,8 @@ private const val LOCATION_PERMISSION_REQUEST_CODE = 1
 class MapsFragment : Fragment(), OnMapReadyCallback, Observer<List<Data>> {
 
     private var viewNetwork: String = ""
+
+    private val MAX_INTENSITY = 10;
 
     private lateinit var mapsViewModel: MapsViewModel
     private lateinit var viewModel: ViewModel
@@ -337,7 +340,8 @@ class MapsFragment : Fragment(), OnMapReadyCallback, Observer<List<Data>> {
                         }
                         continue
                     }
-                    val data = Data(0, network.ssid, lastLocation.latitude, lastLocation.longitude, result.level, Date())
+                    val adjustedLevel = WifiManager.calculateSignalLevel(result.level, MAX_INTENSITY)
+                    val data = Data(0, network.ssid, lastLocation.latitude, lastLocation.longitude, adjustedLevel, Date())
                     viewModel.insertData(data)
                 }
                 if(locationUpdateState) {
@@ -386,7 +390,7 @@ class MapsFragment : Fragment(), OnMapReadyCallback, Observer<List<Data>> {
             Timber.d("Radius of each point: %s", zoomLevel)
         }
         heatmapTileProvider?.setRadius(zoomLevel ?: 10)
-        heatmapTileProvider?.setMaxIntensity(50.0) // based off of analysis of data as we put it in the database.
+        heatmapTileProvider?.setMaxIntensity(MAX_INTENSITY.toDouble())
         heatmapTileProvider?.setWeightedData(heatmapData)
         tileOverlay?.clearTileCache()
     }


### PR DESCRIPTION
this change is really small but modifies the behavior of the database and the heatmap in very important ways. The database will now only store values in range 0 through 10 for the intensity of each data point. This is so that the ScanResult level is no longer a value that could change between devices where the physical Wi-Fi antenna is slightly different.

The heatmap will show red values for good strength signals regardless of the number of points at that location, but the density problem is still present. Too many points, even weak points, will negatively affect the Wi-Fi heatmap, making it look as if the signal is strong when in fact its just that the user has stood in place for a while.